### PR TITLE
Reducción de acoplamiento entre Query y Request (Resolves #2)

### DIFF
--- a/src/Query/Query.php
+++ b/src/Query/Query.php
@@ -12,9 +12,9 @@ class Query implements QueryInterface
     protected $result;
     protected $status;
     protected $error;
-    private $request;
+    private $queryString;
 
-    public function __construct(DateRange $range, RequestForYearInterface $request)
+    public function __construct(DateRange $range, string $clientId)
     {
         $this->range = $range;
         $this->tries = 0;
@@ -22,7 +22,9 @@ class Query implements QueryInterface
         $this->status = new QueryStatusPending();
         $this->error = '';
 
-        $this->request = $request;
+        $args = $range->toArray();
+        $args['id'] = $clientId;
+        $this->queryString = http_build_query($args);
     }
 
     public function range(): DateRange
@@ -70,6 +72,10 @@ class Query implements QueryInterface
         } else {
             $this->status = new QueryStatusResultOk();
         }
-        $this->request->reportQuery($this);
+    }
+
+    public function toQueryString(): string
+    {
+        return $this->queryString;
     }
 }

--- a/src/Query/QueryFactory.php
+++ b/src/Query/QueryFactory.php
@@ -13,24 +13,20 @@ class QueryFactory
         $this->dateRangeFactory = $factory;
     }
 
-    public function buildInitialQueryFromYear(
-        int $year,
-        RequestForYearInterface $request
-    ) {
+    public function buildInitialQueryFromYear(int $year, string $clientId)
+    {
         $range = $this->dateRangeFactory->buildRangeForYear($year);
-        $query = new Query($range, $request);
+        $query = new Query($range, $clientId);
         return $query;
     }
 
-    public function buildQueriesSplitting(
-        QueryInterface $query,
-        RequestForYearInterface $request
-    ) {
+    public function buildQueriesSplitting(QueryInterface $query, string $clientId)
+    {
         $ranges = $this->dateRangeFactory
             ->buildArrayOfRangesSplitting($query->range());
 
-        return array_map(function ($range) use ($request) {
-            return new Query($range, $request);
+        return array_map(function ($range) use ($clientId) {
+            return new Query($range, $clientId);
         }, $ranges);
     }
 }

--- a/src/Query/QueryInterface.php
+++ b/src/Query/QueryInterface.php
@@ -12,4 +12,5 @@ interface QueryInterface
     public function status(): QueryStatus;
     public function error(): string;
     public function saveResult(string $result);
+    public function toQueryString(): string;
 }

--- a/src/Request/RequestForYearComplete.php
+++ b/src/Request/RequestForYearComplete.php
@@ -79,8 +79,8 @@ class RequestForYearComplete implements RequestForYearCompleteInterface
         return $this->requestForYear->getErrorQueries();
     }
 
-    public function reportQuery(QueryInterface $query)
+    public function updateStatus(): bool
     {
-        throw new \LogicException('Query Complete, shouldn\'t receive more reports');
+        return false;
     }
 }

--- a/src/Request/RequestForYearInterface.php
+++ b/src/Request/RequestForYearInterface.php
@@ -12,7 +12,7 @@ interface RequestForYearInterface
 
     public function getQueries(): array;
 
-    public function reportQuery(QueryInterface $query);
+    public function updateStatus(): bool;
 
     public function getErrorQueries(): array;
 }

--- a/tests/Unit/Query/QueryFactoryTest.php
+++ b/tests/Unit/Query/QueryFactoryTest.php
@@ -12,27 +12,27 @@ class QueryFactoryTest extends TestCase
 {
     public function testBuildQueryForWholeYear()
     {
-        $request = $this->createMock(RequestForYearInterface::class);
+        $clientId = 'testing';
 
         $dateRangeFactory = new DateRangeFactory();
         $queryFactory = new QueryFactory($dateRangeFactory);
 
         $expectedDateRange = $dateRangeFactory->buildRangeForYear(2017);
-        $expectedQuery = new Query($expectedDateRange, $request);
+        $expectedQuery = new Query($expectedDateRange, $clientId);
 
-        $query = $queryFactory->buildInitialQueryFromYear(2017, $request);
+        $query = $queryFactory->buildInitialQueryFromYear(2017, $clientId);
 
         $this->assertEquals($expectedQuery, $query);
     }
     public function testBuildQueriesSplittingProvidedOne()
     {
-        $request = $this->createMock(RequestForYearInterface::class);
+        $clientId = 'testing';
 
         $dateRangeFactory = new DateRangeFactory();
 
         $originalRange = $dateRangeFactory
             ->buildFromStrings('2018-01-01', '2018-12-31');
-        $originalQuery = new Query($originalRange, $request);
+        $originalQuery = new Query($originalRange, $clientId);
 
         $queryFactory = new QueryFactory($dateRangeFactory);
 
@@ -40,14 +40,14 @@ class QueryFactoryTest extends TestCase
 
         $expectedRange1 = $dateRangeFactory
             ->buildFromStrings('2018-01-01', '2018-07-02');
-        $expectedQueries[] = new Query($expectedRange1, $request);
+        $expectedQueries[] = new Query($expectedRange1, $clientId);
 
         $expectedRange2 = $dateRangeFactory
             ->buildFromStrings('2018-07-03', '2018-12-31');
-        $expectedQueries[] = new Query($expectedRange2, $request);
+        $expectedQueries[] = new Query($expectedRange2, $clientId);
 
         $queriesBuilt = $queryFactory
-            ->buildQueriesSplitting($originalQuery, $request);
+            ->buildQueriesSplitting($originalQuery, $clientId);
 
         $this->assertEquals($expectedQueries, $queriesBuilt);
     }

--- a/tests/Unit/Query/QueryTest.php
+++ b/tests/Unit/Query/QueryTest.php
@@ -10,13 +10,10 @@ use Jefrancomix\ConsultaFacturas\Query\QueryStatusEndpointError;
 use Jefrancomix\ConsultaFacturas\Query\QueryStatusPending;
 use Jefrancomix\ConsultaFacturas\Query\QueryStatusRangeExceededThreshold;
 use Jefrancomix\ConsultaFacturas\Query\QueryStatusResultOk;
-use Jefrancomix\ConsultaFacturas\Request\RequestForYearInterface;
 use PHPUnit\Framework\TestCase;
-use Prophecy\Argument;
 
 class QueryTest extends TestCase
 {
-    private $request;
     private $query;
     private $range;
     private $dateRangeFactory;
@@ -37,8 +34,6 @@ class QueryTest extends TestCase
             $status = new QueryStatusPending(),
             $error = ''
         );
-        $this->request->reportQuery(Argument::any())
-            ->shouldNotHaveBeenCalled();
     }
 
     public function testQueryResultOk()
@@ -53,7 +48,6 @@ class QueryTest extends TestCase
             $status = new QueryStatusResultOk(),
             $error = ''
         );
-        $this->andThenRequestShouldHaveReceivedReport();
     }
 
     public function testQueryRangeExceededThreshold()
@@ -68,7 +62,6 @@ class QueryTest extends TestCase
             $status = new QueryStatusRangeExceededThreshold(),
             $error = ''
         );
-        $this->andThenRequestShouldHaveReceivedReport();
     }
 
     public function testQueryRangeError()
@@ -83,16 +76,15 @@ class QueryTest extends TestCase
             $status = new QueryStatusEndpointError(),
             $error = 'Error: Endpoint error'
         );
-        $this->andThenRequestShouldHaveReceivedReport();
     }
 
     private function givenInitialQuery()
     {
-        $this->request = $this->prophesize(RequestForYearInterface::class);
+        $clientId = 'testing';
 
         $this->range = $this->dateRangeFactory
             ->buildFromStrings('2017-01-01', '2017-12-31');
-        $this->query = new Query($this->range, $this->request->reveal());
+        $this->query = new Query($this->range, $clientId);
     }
     private function whenRangeInQueryIs(DateRange $rangeExpected)
     {
@@ -112,9 +104,5 @@ class QueryTest extends TestCase
         $this->assertEquals($result, $this->query->result(), "Result mismatch");
         $this->assertEquals($status, $this->query->status(), "Status mismatch");
         $this->assertEquals($error, $this->query->error(), "Error mismatch");
-    }
-    private function andThenRequestShouldHaveReceivedReport()
-    {
-        $this->request->reportQuery($this->query)->shouldHaveBeenCalled();
     }
 }

--- a/tests/Unit/Request/RequestForYearTest.php
+++ b/tests/Unit/Request/RequestForYearTest.php
@@ -28,7 +28,7 @@ class RequestForYearTest extends TestCase
     {
         $this->givenInitialQuery();
 
-        $this->whenInitialQueryIsWholeYear();
+        $this->whenInitialQueryStringIsWholeYear();
 
         $this->thenRequestHaveProperties(
             $isComplete = false,
@@ -85,6 +85,7 @@ class RequestForYearTest extends TestCase
           $this->queriesFactory,
           "http://example.com/"
         );
+        $this->assertCount(1, $this->request->getQueries());
     }
 
     private function whenInitialQuerySucceded()
@@ -92,23 +93,29 @@ class RequestForYearTest extends TestCase
         $queries = $this->request->getQueries();
 
         $queries[0]->saveResult(20);
+
+        $this->request->updateStatus();
     }
 
-    private function whenInitialQueryIsWholeYear()
+    private function whenInitialQueryStringIsWholeYear()
     {
-        $expectedRange = $this->dateRangesFactory
-            ->buildFromStrings('2017-01-01', '2017-12-31');
-        $expectedQuery = new Query($expectedRange, $this->request);
+        $expectedQueryString = 'start=2017-01-01&finish=2017-12-31&id=testing';
 
         $queries = $this->request->getQueries();
 
-        $this->assertEquals($expectedQuery, $queries[0], "Initial Query mismatch");
+        $this->assertEquals(
+            $expectedQueryString,
+            $queries[0]->toQueryString(),
+            "Initial Query mismatch"
+        );
     }
 
     private function whenWholeYearQueryExceedsThreshold()
     {
         $queries = $this->request->getQueries();
         $queries[0]->saveResult('"Hay más de 100 resultados"');
+
+        $this->request->updateStatus();
     }
 
     private function whenLesserRangesSucceed()
@@ -116,6 +123,8 @@ class RequestForYearTest extends TestCase
         $queries = $this->request->getQueries();
         $queries[0]->saveResult(90);
         $queries[1]->saveResult(90);
+
+        $this->request->updateStatus();
     }
     
     private function thenRequestHaveProperties(


### PR DESCRIPTION
- Se obtiene un menor número de llamadas, ya que la Query
  ya no actualiza el status de la Request que la origina.
- La Query ya no tiene enlazada la Request, solo su $clientId
- El Handler de consultas pendientes hace una sola iteración
  para todas las consultas y entonces llama a la Request para
  que actualice su status, en una sola llamada.
- Esto facilita hacer paralelas las consultas con Guzzle o
  directamente con curl_multi_exec.